### PR TITLE
Improved Input widgets

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,10 +1,10 @@
-version = "2.4.2"
+version = "2.5.0"
 style = default
 
 maxColumn = 100
 
 // Vertical alignment is pretty, but leads to bigger diffs
-align = most
+align.preset = most
 
 rewrite.rules = [
   AvoidInfix

--- a/src/main/scala/gpp/ui/forms/EnumSelect.scala
+++ b/src/main/scala/gpp/ui/forms/EnumSelect.scala
@@ -22,15 +22,15 @@ final case class EnumSelect[A](
   placeholder: String,
   disabled:    Boolean,
   onChange:    A => Callback = (_: A) => Callback.empty
-)(
-  implicit val enum: Enumerated[A],
-  val show:          Show[A]
+)(implicit
+  val enum:    Enumerated[A],
+  val show:    Show[A]
 ) extends ReactProps {
   @inline def render: VdomElement =
     EnumSelect.component(this.asInstanceOf[EnumSelect[Any]])
 }
 
-object EnumSelect {
+object EnumSelect      {
   type Props[A] = EnumSelect[A]
 
   implicit protected def propsReuse[A]: Reusability[Props[A]] =
@@ -48,9 +48,9 @@ object EnumSelect {
           <.label(p.label),
           Select(
             placeholder = p.placeholder,
-            fluid       = true,
-            disabled    = p.disabled,
-            value       = p.value.map(i => p.enum.tag(i)).orUndefined,
+            fluid = true,
+            disabled = p.disabled,
+            value = p.value.map(i => p.enum.tag(i)).orUndefined,
             options = p.enum.all
               .map(i => DropdownItem(text = i.show, value = p.enum.tag(i))),
             onChange = (ddp: Dropdown.DropdownProps) =>

--- a/src/main/scala/gpp/ui/forms/FormInputEV.scala
+++ b/src/main/scala/gpp/ui/forms/FormInputEV.scala
@@ -55,17 +55,17 @@ final case class FormInputEV[A](
   transparent:    js.UndefOr[Boolean] = js.undefined,
   width:          js.UndefOr[SemanticWidth] = js.undefined,
   snapshot:       StateSnapshot[A],
-  prism:          Prism[A, String] = Iso.id[String].asPrism,
+  prism:          Prism[String, A] = Iso.id[String].asPrism,
   onChange:       FormInputEV.ChangeCallback[A] = (_: A) => Callback.empty, // callback for parents of this component
   onBlur:         FormInputEV.ChangeCallback[A] = (_: A) => Callback.empty
 ) extends ReactProps {
   @inline def render: VdomElement = FormInputEV.component(this)
-  def valGet: String              = prism.getOption(snapshot.value).orEmpty
-  def valSet(s: String): Callback = snapshot.setState(prism.reverseGet(s))
-  val onBlurC: FormInputEV.ChangeCallback[String] =
-    (s: String) => onBlur(prism.reverseGet(s))
-  val onChangeC: FormInputEV.ChangeCallback[String] =
-    (s: String) => onChange(prism.reverseGet(s))
+  def valGet: String              = prism.reverseGet(snapshot.value)
+  def valSet(s: String): Callback = prism.getOption(s).map(snapshot.setState).getOrEmpty
+  val onBlurC: InputEV.ChangeCallback[String] =
+    (s: String) => prism.getOption(s).map(onBlur).getOrEmpty
+  val onChangeC: InputEV.ChangeCallback[String] =
+    (s: String) => prism.getOption(s).map(onChange).getOrEmpty
 }
 
 object FormInputEV {

--- a/src/main/scala/gpp/ui/forms/InputEV.scala
+++ b/src/main/scala/gpp/ui/forms/InputEV.scala
@@ -19,7 +19,7 @@ final case class InputEV[A](
   name:        String,
   id:          String,
   snapshot:    StateSnapshot[A],
-  prism:       Prism[A, String] = Iso.id[String].asPrism,
+  prism:       Prism[String, A] = Iso.id[String].asPrism,
   inputType:   InputEV.InputType = InputEV.TextInput,
   placeholder: String = "",
   disabled:    Boolean = false,
@@ -27,12 +27,12 @@ final case class InputEV[A](
   onBlur:      InputEV.ChangeCallback[A] = (_: A) => Callback.empty
 ) extends ReactProps {
   @inline def render: VdomElement = InputEV.component(this)
-  def valGet: String              = prism.getOption(snapshot.value).orEmpty
-  def valSet(s: String): Callback = snapshot.setState(prism.reverseGet(s))
+  def valGet: String              = prism.reverseGet(snapshot.value)
+  def valSet(s: String): Callback = prism.getOption(s).map(snapshot.setState).getOrEmpty
   val onBlurC: InputEV.ChangeCallback[String] =
-    (s: String) => onBlur(prism.reverseGet(s))
+    (s: String) => prism.getOption(s).map(onBlur).getOrEmpty
   val onChangeC: InputEV.ChangeCallback[String] =
-    (s: String) => onChange(prism.reverseGet(s))
+    (s: String) => prism.getOption(s).map(onChange).getOrEmpty
 }
 
 object InputEV {

--- a/src/main/scala/gpp/ui/forms/InputOptic.scala
+++ b/src/main/scala/gpp/ui/forms/InputOptic.scala
@@ -1,0 +1,61 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package gpp.ui.forms
+
+import cats.implicits._
+import gsp.math.optics.Format
+import monocle.Prism
+import monocle.Iso
+
+/**
+  * Define an object that can convert from A to String and optionally viceversa
+  * It is meant to be used for Input widgets targeting some A
+  * Can be easily constructed from Monocle Optics
+  */
+trait InputOptics[A] {
+
+  /** get the source as a string */
+  def reverseGet(a: A): String
+
+  /** convert a string to a possible output */
+  def getOption(s: String): Option[A]
+}
+
+object InputOptics {
+  val id: InputOptics[String] = fromIso(Iso.id[String])
+
+  def apply[A](_getOption:  String => Option[A])(_reverseGet: A => String): InputOptics[A] =
+    new InputOptics[A] {
+      def reverseGet(a: A): String         = _reverseGet(a)
+      def getOption(s:  String): Option[A] = _getOption(s)
+    }
+
+  /**
+    * Build optics from a Prism
+    */
+  def fromPrism[A](prism:   Prism[String, A]) =
+    new InputOptics[A] {
+      def reverseGet(a: A): String         = prism.reverseGet(a)
+      def getOption(s:  String): Option[A] = prism.getOption(s)
+    }
+
+  /**
+    * Build optics from a Iso
+    */
+  def fromIso[A](iso:       Iso[String, A]): InputOptics[A] =
+    new InputOptics[A] {
+      def reverseGet(a: A): String         = iso.reverseGet(a)
+      def getOption(s:  String): Option[A] = iso.get(s).some
+    }
+
+  /**
+    * Build optics from a Format
+    */
+  def fromFormat[A](format: Format[String, A])              =
+    new InputOptics[A] {
+      def reverseGet(a: A): String         = format.reverseGet(a)
+      def getOption(s:  String): Option[A] = format.getOption(s)
+    }
+
+}


### PR DESCRIPTION
This PR fixes an issue with the Input fields where the `Prism` had the types reversed
It also adds an `InputOptics` typeclass like construct to let you build `Input` based on `Prism/Format/Iso`